### PR TITLE
Fix orientation error in command (#29)

### DIFF
--- a/fleet_adapter_mir/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/fleet_adapter_mir/MiRCommandHandle.py
@@ -417,7 +417,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                             ]
                         )
                         _mir_ori_rad = \
-                            _next_waypoint.position[2] - self.transforms['rmf_to_mir'].get_rotation()
+                            _next_waypoint.position[2] + self.transforms['rmf_to_mir'].get_rotation()
                         _mir_ori = math.degrees(_mir_ori_rad % (2 * math.pi))
 
                         if _mir_ori > 180.0:


### PR DESCRIPTION
The orientation of the transform from RMF to MiR should be added (and not deducted) to the robot orientation in the RMF map frame in order to get the orientation in the MiR map frame.